### PR TITLE
Improve support-site copy and screenshot captions for discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@
 </p>
 
 <p align="center">
-  <img src="screenshots/screenshot1.png" alt="Profile View" width="200">
-  <img src="screenshots/screenshot2.png" alt="AI Rewrite" width="200">
-  <img src="screenshots/screenshot3.png" alt="Copy Flow" width="200">
+  <img src="screenshots/screenshot1.png" alt="Welcome — write once, use on any app" width="200">
+  <img src="screenshots/screenshot2.png" alt="Profile with one-tap copy for Tinder, Bumble, Hinge" width="200">
+  <img src="screenshots/screenshot3.png" alt="Rewrite your bio with on-device AI" width="200">
 </p>
 
 ## About the App
 
-Dating Profile Vault helps you create, manage, and optimize your dating profile content. Write your bio once, refine it with AI, and copy it to any dating app.
+Dating Profile Vault is a dating bio generator and profile vault. Write your Tinder, Bumble, and Hinge bio once, sharpen it with free on-device AI, and copy it to any dating app — no account, no cloud.
 
 **Features:**
-- Store bios, interests, and prompt answers in one place
-- AI-powered rewrites using Apple Intelligence (on-device)
-- One-tap copy formatted for Tinder, Bumble, Hinge
-- All data stored locally - no accounts, no cloud sync
+- Store your dating bio, interests, and Hinge/Bumble prompt answers in one place
+- AI-powered bio rewrites using Apple Intelligence — on-device, no account
+- One-tap copy formatted for Tinder, Bumble, and Hinge
+- Private by design: all data stays on your device — no accounts, no cloud sync, no tracking
 
 ## Links
 

--- a/index.html
+++ b/index.html
@@ -63,14 +63,22 @@
         .screenshot {
             flex-shrink: 0;
             width: 160px;
-            border-radius: 12px;
-            overflow: hidden;
-            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
         .screenshot img {
             width: 100%;
             height: auto;
             display: block;
+            border-radius: 12px;
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+        }
+        .screenshot-caption {
+            margin-top: 10px;
+            font-size: 13px;
+            line-height: 1.3;
+            color: #a0a0a0;
         }
         .features {
             background: rgba(255, 255, 255, 0.05);
@@ -148,13 +156,16 @@
 
         <div class="screenshots">
             <div class="screenshot">
-                <img src="screenshots/screenshot1.png" alt="App Screenshot 1">
+                <img src="screenshots/screenshot1.png" alt="Welcome screen: write your dating profile once and use it on any app">
+                <span class="screenshot-caption">Write once, use on any app</span>
             </div>
             <div class="screenshot">
-                <img src="screenshots/screenshot2.png" alt="App Screenshot 2">
+                <img src="screenshots/screenshot2.png" alt="Profile screen with bio, interests, and prompts, each with one-tap copy for Tinder, Bumble, and Hinge">
+                <span class="screenshot-caption">Bio, interests &amp; prompts — copy in one tap</span>
             </div>
             <div class="screenshot">
-                <img src="screenshots/screenshot3.png" alt="App Screenshot 3">
+                <img src="screenshots/screenshot3.png" alt="AI rewrite sheet that refines your bio on-device with Apple Intelligence">
+                <span class="screenshot-caption">Rewrite with free on-device AI</span>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary

Improves the support site (the only assets in this repo) to support the App Store discovery / ASO work tracked in #11. No app-code changes — those live in the iOS app source repo and are captured as issues #1–#11.

## Changes

**`index.html`**
- Replaced generic `alt="App Screenshot 1/2/3"` with descriptive alt text (accessibility + SEO).
- Added value-led captions under each screenshot:
  - "Write once, use on any app"
  - "Bio, interests & prompts — copy in one tap"
  - "Rewrite with free on-device AI"
- Restructured `.screenshot` to a flex column so captions sit below the rounded, shadowed image (border-radius/shadow moved onto the `img`).

**`README.md`**
- Rewrote the description and feature list with natural search-intent phrasing (dating bio, Hinge/Bumble prompts, on-device AI, private-by-design).
- Aligned screenshot alt labels to what each screen actually shows.

## Related issues

Part of the review turned into the backlog #1–#11. Directly advances #11 (ASO — support-site copy).

## Not addressed here (needs a decision)

The README/landing page link support & privacy to `spicyintelchip.github.io/DatingProfileVault/`, but this repo is `clockmath/DatingProfileVault`. Left the live URLs untouched to avoid breaking the App Store support link — needs confirmation of the canonical Pages URL before changing.

## Test plan

- [ ] `index.html` renders with three captioned screenshots; layout intact on mobile widths.
- [ ] `README.md` preview reads correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014KA9q5bS1Ac2KKYUD3CwBC)_